### PR TITLE
Escape preg_match and save responses

### DIFF
--- a/src/Klout/Klout.php
+++ b/src/Klout/Klout.php
@@ -62,6 +62,13 @@ class Klout
      * @var \Guzzle\Http\Client
      */
     protected $client;
+    
+    /**
+     * Used to disable assertValidUserIdForNetwork validation for characters
+     * 
+     * @var boolean
+     */
+    protected $escapeValidation = false;
 
     /**
      * Constructor
@@ -485,11 +492,22 @@ class Klout
                 }
                 break;
             default:
-                if (!preg_match('/^[A-Za-z0-9]*$/', $networkUserId)) {
+                if (!preg_match('/^[A-Za-z0-9]*$/', $networkUserId) && $this->escapeValidation == false) {
                     throw new InvalidArgumentException("'$networkUserId'" . ' is not a valid network user ID.');
                 }
                 break;
         }
+    }
+    
+    /**
+     * Don't let assertValidUserIdForNetwork to throw exception based on characters
+     * 
+     * @return $this
+     */
+    public function escapeValidation(){
+        $this->escapeValidation = true;
+        
+        return $this;
     }
 
 }

--- a/src/Klout/Model/User.php
+++ b/src/Klout/Model/User.php
@@ -71,6 +71,20 @@ class User extends AbstractModel
     protected $topics;
 
     /**
+     * Data returned from klout about user influencers
+     * 
+     * @var array
+     */
+    protected $savedInfluencers;
+
+    /**
+     * Data returned from klout about user topics
+     * 
+     * @var array
+     */
+    protected $savedTopics;
+
+    /**
      * The constructor
      *
      * @param array $userData      (optional)
@@ -281,6 +295,46 @@ class User extends AbstractModel
 
         return $this;
     }
+    
+    /**
+     * Save Klout influencers response data
+     * 
+     * @param $data
+     */
+    public function saveInfluencers($data){
+        $this->savedInfluencers = $data;
+
+        return $this;
+    }
+    
+     /**
+     * Save Klout topics response data
+     * 
+     * @param $data
+     */
+    public function saveTopics($data){
+        $this->savedTopics = $data;
+
+        return $this;
+    }
+    
+     /**
+     * Get Klout influencers response data
+     * 
+     * @param $data
+     */
+    public function getSavedInfluencers(){
+        return $this->savedInfluencers;
+    }
+    
+     /**
+     * Get Klout topics response data
+     * 
+     * @param $data
+     */
+    public function getSavedTopics(){
+        return $this->savedTopics;
+    }
 
     /**
      * Populate the object with an array of data
@@ -327,6 +381,7 @@ class User extends AbstractModel
         $influencees = new UserCollection();
         if (!empty($influenceData)) {
             if (isset($influenceData['myInfluencers']) && !empty($influenceData['myInfluencers'])) {
+                $this->saveInfluencers($influenceData['myInfluencers']);
                 $influencersData = array();
                 foreach ($influenceData['myInfluencers'] as $value) {
                     if (empty($value['entity']) || empty($value['entity']['payload'])) {
@@ -351,8 +406,10 @@ class User extends AbstractModel
 
         $this->setInfluencers($influencers);
         $this->setInfluencees($influencees);
-
+    
         if (!empty($topicsData)) {
+            //save topics data
+            $this->saveTopics($topicsData);
             $this->setTopics(Topic::createTopicCollection($topicsData));
         }
 


### PR DESCRIPTION
- ddf941bbfa6bd4736418e1e91a5137e791607822 - When using `php $this->getUserByTwitterUsername()`, if Twitter username has an underscore or similar (@example_username), `php $this->assertValidUserIdForNetwork()` will throw an error and not allow the username to be pulled through Klout. This is a quick workaround to disable preg_match.
- 0928c19031807984efdfec09712c55aaa99b9e5b - Allow us to return the entire Klout response from influencers and topics e.g with the same array structure
